### PR TITLE
Add settings to display only on selected view modes

### DIFF
--- a/janrain_capture.links.menu.yml
+++ b/janrain_capture.links.menu.yml
@@ -1,5 +1,5 @@
-janrain_capture.settings:
+janrain_capture.drupal_settings:
   title: 'Janrain Capture'
   description: 'Configure Janrain Capture settings.'
   parent: user.admin_index
-  route_name: janrain_capture.settings.capture
+  route_name: janrain_capture.settings

--- a/janrain_capture.links.task.yml
+++ b/janrain_capture.links.task.yml
@@ -1,9 +1,19 @@
+janrain_capture.settings_tab:
+  route_name: janrain_capture.settings
+  title: Janrain Capture
+  base_route: entity.user.collection
+
+janrain_capture.drupal_settings_tab:
+  route_name: janrain_capture.settings
+  title: Drupal settings
+  base_route: janrain_capture.settings
+
 janrain_capture.capture_settings_tab:
   route_name: janrain_capture.settings.capture
   title: Capture settings
-  base_route: janrain_capture.settings.capture
+  base_route: janrain_capture.settings
 
 janrain_capture.screens_settings_tab:
   route_name: janrain_capture.settings.screens
   title: Screens settings
-  base_route: janrain_capture.settings.capture
+  base_route: janrain_capture.settings

--- a/janrain_capture.module
+++ b/janrain_capture.module
@@ -52,6 +52,13 @@ function janrain_capture_page_bottom(array &$page_bottom): void {
  * @internal
  */
 function janrain_capture_user_view(array &$build, UserInterface $user): void {
+  // Only display user screen based on user view mode settings.
+  $config = \Drupal::config('janrain_capture.drupal_settings');
+  $view_modes = $config->get('capture.view_modes');
+  if (!in_array($build['#view_mode'], $view_modes, TRUE)) {
+    return;
+  }
+
   if (\Drupal::service('janrain_capture.capture_api')->isJanrainAccount($user)) {
     $build += \Drupal::service('janrain_capture.markup_builder')->getScreenRenderArray('public-profile');
   }

--- a/janrain_capture.routing.yml
+++ b/janrain_capture.routing.yml
@@ -16,6 +16,12 @@ janrain_capture.simple_logout:
     _controller: '\Drupal\janrain_capture\Controller\AuthenticationController::logout'
   requirements:
       _access: 'TRUE'
+janrain_capture.xdcomm:
+  path: '/janrain_capture/xdcomm'
+  defaults:
+    _controller: '\Drupal\janrain_capture\Controller\AuthenticationController::xdcomm'
+  requirements:
+      _access: 'TRUE'
 janrain_capture.settings.capture:
   path: '/admin/config/people/janrain-capture/capture-settings'
   defaults:
@@ -26,5 +32,11 @@ janrain_capture.settings.screens:
   path: '/admin/config/people/janrain-capture/screens-settings'
   defaults:
     _form: '\Drupal\janrain_capture\Form\JanrainScreensSettingsForm'
+  requirements:
+    _permission: 'administer site configuration'
+janrain_capture.settings:
+  path: '/admin/config/people/janrain-capture'
+  defaults:
+    _form: '\Drupal\janrain_capture\Form\JanrainCaptureDrupalSettingsForm'
   requirements:
     _permission: 'administer site configuration'

--- a/src/Form/JanrainCaptureDrupalSettingsForm.php
+++ b/src/Form/JanrainCaptureDrupalSettingsForm.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Drupal\janrain_capture\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Entity\Entity\EntityViewMode;
+use Drupal\Core\Entity\EntityTypeManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Janrain Capture settings form for Drupal config.
+ */
+class JanrainCaptureDrupalSettingsForm extends ConfigFormBase {
+
+  /**
+   * Entity type manager.
+   *
+   * @var Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * JanrainCaptureDrupalSettingsForm constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   *   Entity type manager.
+   */
+  public function __construct(EntityTypeManager $entityTypeManager) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['janrain_capture.drupal_settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'janrain_capture.drupal_settings.capture';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildForm($form, $form_state);
+    $config = $this->config('janrain_capture.drupal_settings');
+
+    $form['capture'] = [
+      '#type' => 'fieldset',
+      '#tree' => TRUE,
+      '#title' => $this->t('Janrain Capture Drupal settings'),
+    ];
+    $view_modes = $this->entityTypeManager->getStorage('entity_view_mode')->getQuery()
+      ->condition('targetEntityType', 'user')
+      ->execute();
+    $view_modes = EntityViewMode::loadMultiple($view_modes);
+    $options = [];
+    foreach ($view_modes as $id => $view_mode) {
+      $id = str_replace('user.', '', $id);
+      $options[$id] = $view_mode->label();
+    }
+
+    $form['capture']['view_modes'] = [
+      '#type' => 'select',
+      '#title' => $this->t('User view modes'),
+      '#options' => $options,
+      '#multiple' => TRUE,
+      '#description' => $this->t('Select which view modes to activate Janrain user profile.'),
+      '#default_value' => $config->get('capture.view_modes'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $capture = $form_state->getValue('capture');
+
+    $this->configFactory->getEditable('janrain_capture.drupal_settings')
+      ->set('capture.view_modes', $capture['view_modes'])
+      ->save();
+  }
+
+}


### PR DESCRIPTION
GRV profile is displaying wherever User entities are displayed.
This commit provides an admin interface to set view modes and only displays user profile in those view modes.